### PR TITLE
added getLogs functionality using eth_getLogs

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -49,6 +49,7 @@ __export(exports, {
   encodeCallSignature: () => encodeCallSignature,
   errors: () => errors,
   getBlockByNumber: () => getBlockByNumber,
+  getLogs: () => getLogs,
   getStorageAt: () => getStorageAt,
   getStorageLocation: () => getStorageLocation,
   nodes: () => nodes_default,
@@ -282,6 +283,23 @@ async function call(options, from, to, data, blockNumber = "latest") {
   return await send(options, body);
 }
 
+// src/getLogs.js
+var { id: id5, jsonrpc: jsonrpc5 } = constants_default;
+async function getLogs(options, { fromBlock, toBlock, address, topics, limit } = {}) {
+  const body = {
+    method: "eth_getLogs",
+    params: [{ fromBlock, toBlock, address, topics, limit }],
+    id: id5,
+    jsonrpc: jsonrpc5
+  };
+  for (const value in body.params[0]) {
+    if (!body.params[0][value]) {
+      delete body.params[0][value];
+    }
+  }
+  return await send(options, body);
+}
+
 // src/index.js
 var errors = {
   RPCError
@@ -296,6 +314,7 @@ var errors = {
   encodeCallSignature,
   errors,
   getBlockByNumber,
+  getLogs,
   getStorageAt,
   getStorageLocation,
   nodes,

--- a/readme.md
+++ b/readme.md
@@ -292,7 +292,7 @@ filterObject = {
 
 All the options in filterObject are optional. For more details, see [_Open Ethereum Documentation_](https://openethereum.github.io/JSONRPC-eth-module#eth_getlogs).
 
-See, https://ethereum.stackexchange.com/a/12951 for information about events and how to filter them using topics.
+See, [Ethereum's StackExchange](https://ethereum.stackexchange.com/a/12951) for information about events and how to filter them using topics.
 
 ```js
 import { getLogs } from "eth-fun";

--- a/readme.md
+++ b/readme.md
@@ -276,7 +276,7 @@ console.log(fns);
 // }
 ```
 
-### `getLogs(options, {fromBlock, toBlock, address, topics, limit })`
+### `async getLogs(options, {fromBlock, toBlock, address, topics, limit })`
 
 Returns an array of all logs matching a given filterObject. [Events](https://docs.soliditylang.org/en/develop/contracts.html?highlight=topic#events) emitted in smart contracts are stored as transaction's log.
 
@@ -340,7 +340,7 @@ import { getLogs } from "eth-fun";
 
 #### Notes
 
-- Eth clients such as `https://cloudflare-eth.com` only support logs of the latest 128 blocks.
+- Some Ethereum nodes such as `https://cloudflare-eth.com` only support logs of the latest 128 blocks.
 
 ## Changelog
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 ## Why Use eth-fun?
 
-You should use eth-fun when you want to have _fun_. eth-fun is built with a 
+You should use eth-fun when you want to have _fun_. eth-fun is built with a
 functional approach in mind. We try to build our code according to the properties
 below. eth-fun's codebase shall be:
 
@@ -33,10 +33,10 @@ $ npm i eth-fun
 `options` are passed to any JSON-RPC call. They may contain the following
 properties:
 
-|name|required?|default|
-|---|---|---|
-|url|yes|`undefined`|
-|headers|no|`{"Content-Type": "application/json"}`|
+| name    | required? | default                                |
+| ------- | --------- | -------------------------------------- |
+| url     | yes       | `undefined`                            |
+| headers | no        | `{"Content-Type": "application/json"}` |
 
 ### `await getBlockByNumber(options, blockNumber, includeTxBodies)`
 
@@ -47,8 +47,8 @@ transaction hashes instead of all transaction bodies.
 ```js
 import { blockNumber, getBlockByNumber } from "eth-fun";
 
-const options = { 
-  url: "https://cloudflare-eth.com"
+const options = {
+  url: "https://cloudflare-eth.com",
 };
 
 (async () => {
@@ -69,7 +69,7 @@ import { toHex } from "eth-fun";
 
 const num = 20;
 const hexNum = toHex(num);
-console.log(hexNum)
+console.log(hexNum);
 // 0x14
 ```
 
@@ -77,7 +77,7 @@ console.log(hexNum)
 
 Given some meta data about a contract's function signature, it generates a
 hex-encoded Solidity string that can be passed as `data` parameter to e.g. a
-`eth_call`.  For reference, see Solidity's [ABI encoding
+`eth_call`. For reference, see Solidity's [ABI encoding
 specification](https://docs.soliditylang.org/en/develop/abi-spec.html).
 
 ```js
@@ -100,8 +100,9 @@ a hex-encoded Solidity string to human-readable return values.
 ```js
 import { decodeCallOutput } from "eth-fun";
 const types = ["uint256"];
-const output = "0x00000000000000000000000000000000000000000000000041eb63d55b1b0000";
-const [ returnVal ] = decodeCallOutput(types, output);
+const output =
+  "0x00000000000000000000000000000000000000000000000041eb63d55b1b0000";
+const [returnVal] = decodeCallOutput(types, output);
 console.log(returnVal);
 // 4750000000000000000
 ```
@@ -109,7 +110,7 @@ console.log(returnVal);
 ### `async call(options, from, to, data, blockNumber)`
 
 Executes an Ethereum message call directy and without creating a
-transaction.  For information to how to encode `data`, see function
+transaction. For information to how to encode `data`, see function
 description of `encodeCallSignature`. And for description on how to
 decode an eth call's output, see `decodeCallOutput`.
 
@@ -118,10 +119,11 @@ import { call } from "eth-fun";
 
 (async () => {
   const options = {
-    url: "https://cloudflare-eth.com"
+    url: "https://cloudflare-eth.com",
   };
   const to = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
-  const data = "0x70a08231000000000000000000000000005241438caf3eacb05bb6543151f7af894c5b58";
+  const data =
+    "0x70a08231000000000000000000000000005241438caf3eacb05bb6543151f7af894c5b58";
 
   const output = await call(options, null, to, data);
   console.log(output);
@@ -164,12 +166,12 @@ Gets the latest block number from the Ethereum node in `url`.
 import { blockNumber } from "eth-fun";
 
 const options = {
-  url: "https://cloudflare-eth.com"
+  url: "https://cloudflare-eth.com",
 };
 
 (async () => {
   const number = await blockNumber(options);
-  console.log(number)
+  console.log(number);
 })();
 ```
 
@@ -186,12 +188,12 @@ For a given contract `addr`, retrieves the storage value at `index` for
 import { getStorageAt } from "eth-fun";
 
 const options = {
-  url: "https://cloudflare-eth.com"
+  url: "https://cloudflare-eth.com",
 };
 const addr = "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984";
 
 const number = await getStorageAt(options, addr, 0, "latest");
-console.log(number)
+console.log(number);
 ```
 
 #### Notes
@@ -274,6 +276,72 @@ console.log(fns);
 // }
 ```
 
+### `getLogs(options, {fromBlock, toBlock, address, topics, limit })`
+
+Returns an array of all logs matching a given filterObject. [Events](https://docs.soliditylang.org/en/develop/contracts.html?highlight=topic#events) emitted in smart contracts are stored as transaction's log.
+
+```txt
+filterObject = {
+  fromBlock,
+  toBlock,
+  address,
+  topics,
+  limit,
+};
+```
+
+All the options in filterObject are optional. For more details, see [_Open Ethereum Documentation_](https://openethereum.github.io/JSONRPC-eth-module#eth_getlogs).
+
+See, https://ethereum.stackexchange.com/a/12951 for information about events and how to filter them using topics.
+
+```js
+import { getLogs } from "eth-fun";
+
+(async () => {
+  const options = {
+    url: "https://nodes.mewapi.io/rpc/eth",
+  };
+
+  const output = await getLogs(options, {
+    fromBlock: "0xc60891",
+    toBlock: null,
+    address: "0x8b0acaa0cdc89f0a76acd246177dd75b9614af43",
+    topics: [
+      "0xe1c4fa794edfa8f619b8257a077398950357b9c6398528f94480307352f9afcc",
+    ],
+  });
+
+  console.log(output);
+})();
+
+/*
+[
+  {
+    address: "0x8b0acaa0cdc89f0a76acd246177dd75b9614af43",
+    blockHash:
+      "0xad5fc40d69d8e14a98653052b9dcca6b374d07a5a13f99fb8de90efd7e222574",
+    blockNumber: "0xc60891",
+    data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000610e8fd400000000000000000000000000000000000000000000000000038d7ea4c68000",
+    logIndex: "0x80",
+    removed: false,
+    topics: [
+      "0xe1c4fa794edfa8f619b8257a077398950357b9c6398528f94480307352f9afcc",
+      "0x000000000000000000000000bbd33afa85539fa65cc08a2e61a001876d2f13fe",
+      "0x000000000000000000000000bbd33afa85539fa65cc08a2e61a001876d2f13fe",
+      "0x000000000000000000000000903322c7e45a60d7c8c3ea236c5bea9af86310c7",
+    ],
+    transactionHash:
+      "0x231a00b46517e6a53c5a05f7c2053319d610ef25f7066e1f90434aaa353f40e4",
+    transactionIndex: "0xa0",
+  },
+];
+*/
+```
+
+#### Notes
+
+- Eth clients such as `https://cloudflare-eth.com` only support logs of the latest 128 blocks.
+
 ## Changelog
 
 ### 0.5.0
@@ -287,7 +355,7 @@ console.log(fns);
 ### 0.3.0
 
 - (Breaking change) Change `node` (it was a URL) function parameter to
-`options` object for all JSON-RPC functions
+  `options` object for all JSON-RPC functions
 - (Breaking change) Rename `ethCall` to `call`
 - Expose `toHex` function
 - Add `getBlockByNumber` function
@@ -315,18 +383,18 @@ console.log(fns);
 - Add `compile` function
 - (Breaking change) Separate `allFunctions` and `compile` function
 - (Breaking change) Change `allFunctions` function signature. Output now
-returns an object of named contracts with the list of functions.
+  returns an object of named contracts with the list of functions.
 
 ### 0.0.1
 
 - Initial release
 - Add `allFunctions` function that returns all functions of a contract in a
-`.sol` file.
+  `.sol` file.
 
 ## Caveats
 
 - Currently we're pinning
-  [solc@0.6.12](https://www.npmjs.com/package/solc/v/0.6.12).  For future
+  [solc@0.6.12](https://www.npmjs.com/package/solc/v/0.6.12). For future
   versions, it'd be awesome if the version could be specified by the user.
 
 ## References
@@ -335,7 +403,6 @@ returns an object of named contracts with the list of functions.
 - [Ethereum openrpc specification](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/lightclient/eth1.0-apis/main/openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false)
 - [Geth docs RPC server](https://geth.ethereum.org/docs/rpc/server)
 - [OpenEthereum JSON RPC API](https://openethereum.github.io/JSONRPC)
-
 
 ## License
 

--- a/src/getLogs.js
+++ b/src/getLogs.js
@@ -1,0 +1,33 @@
+import constants from "./constants.js";
+import { send } from "./transport.js";
+
+const { id, jsonrpc } = constants;
+
+/**
+ * See https://openethereum.github.io/JSONRPC-eth-module#eth_getlogs
+ *
+ * @param {*} options
+ * @param {*} filterObject
+ * @returns
+ */
+export default async function getLogs(
+  options,
+  { fromBlock, toBlock, address, topics, limit } = {}
+) {
+  const body = {
+    method: "eth_getLogs",
+    params: [{ fromBlock, toBlock, address, topics, limit }],
+    id,
+    jsonrpc,
+  };
+
+  // Remove falsy values from params
+  // We don't want to send null values
+  for (const value in body.params[0]) {
+    if (!body.params[0][value]) {
+      delete body.params[0][value];
+    }
+  }
+
+  return await send(options, body);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,10 @@ import nodes from "./nodes.js";
 import { RPCError } from "./errors.js";
 import { call, encodeCallSignature, decodeCallOutput } from "./call.js";
 import { toHex } from "./utils.js";
+import getLogs from "./getLogs.js";
 
 const errors = {
-  RPCError
+  RPCError,
 };
 
 export {
@@ -27,4 +28,5 @@ export {
   decodeCallOutput,
   toHex,
   getBlockByNumber,
+  getLogs,
 };

--- a/src/transport.js
+++ b/src/transport.js
@@ -18,7 +18,7 @@ export async function send(options, body) {
   const res = await fetch(url, {
     method: "POST",
     headers,
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
   });
 
   if (res.status === 403) {

--- a/test/getLogs_test.js
+++ b/test/getLogs_test.js
@@ -1,0 +1,38 @@
+import test from "ava";
+import getLogs from "../src/getLogs.js";
+
+const options = {
+  url: "https://nodes.mewapi.io/rpc/eth",
+};
+
+test("fetch logs from a given range of block numbers", async (t) => {
+  const output = await getLogs(options, {
+    fromBlock: "0xc60891",
+    toBlock: null,
+    address: "0x8b0acaa0cdc89f0a76acd246177dd75b9614af43",
+    topics: [
+      "0xe1c4fa794edfa8f619b8257a077398950357b9c6398528f94480307352f9afcc",
+    ],
+  });
+
+  t.deepEqual(output, [
+    {
+      address: "0x8b0acaa0cdc89f0a76acd246177dd75b9614af43",
+      blockHash:
+        "0xad5fc40d69d8e14a98653052b9dcca6b374d07a5a13f99fb8de90efd7e222574",
+      blockNumber: "0xc60891",
+      data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000610e8fd400000000000000000000000000000000000000000000000000038d7ea4c68000",
+      logIndex: "0x80",
+      removed: false,
+      topics: [
+        "0xe1c4fa794edfa8f619b8257a077398950357b9c6398528f94480307352f9afcc",
+        "0x000000000000000000000000bbd33afa85539fa65cc08a2e61a001876d2f13fe",
+        "0x000000000000000000000000bbd33afa85539fa65cc08a2e61a001876d2f13fe",
+        "0x000000000000000000000000903322c7e45a60d7c8c3ea236c5bea9af86310c7",
+      ],
+      transactionHash:
+        "0x231a00b46517e6a53c5a05f7c2053319d610ef25f7066e1f90434aaa353f40e4",
+      transactionIndex: "0xa0",
+    },
+  ]);
+});

--- a/test/import_cjs_build.cjs
+++ b/test/import_cjs_build.cjs
@@ -17,6 +17,7 @@ test("Import CommonJS build", (t) => {
       "decodeCallOutput",
       "toHex",
       "getBlockByNumber",
+      "getLogs",
     ].sort()
   );
 

--- a/test/readme_test.js
+++ b/test/readme_test.js
@@ -16,11 +16,11 @@ content = content.replace(
 const blocks = matchBlocks("js", content);
 
 for (let block of blocks) {
-  test(`run ${block.split("\n")[0]}`, async t => {
+  test(`run ${block.split("\n")[0]}`, async (t) => {
     try {
       await exec(block);
     } catch (err) {
-      console.log(err);
+      t.log(err); // prints log alongside the test instead of immediately printing them to stdout
       t.fail();
     }
 


### PR DESCRIPTION
Closes #17 

- [x] Added `getLogs` function
- [x] Added unit test
- [x] Updated readme

For testing purposes I have used the `https://nodes.mewapi.io/rpc/eth` node. For some unknown reason Cloudflare was returning an error. Cloudflare only provides logs for the latest 128 blocks but even if I used the latest block number the error didn't resolve. I double checked everything but the problem seems to be with Cloudflare. I also tested the function with a infura node and it worked fine.

This is another reason to mock network calls in tests. I'll pick #14 next.