### PR TITLE
Mock network calls in test

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -132,8 +132,6 @@ async function send(options, body) {
   } else {
     url = options.url;
   }
-  console.log(body.method);
-  console.log(body);
   const res = await (0, import_cross_fetch.default)(url, {
     method: "POST",
     headers,

--- a/cjs/index.js
+++ b/cjs/index.js
@@ -132,6 +132,8 @@ async function send(options, body) {
   } else {
     url = options.url;
   }
+  console.log(body.method);
+  console.log(body);
   const res = await (0, import_cross_fetch.default)(url, {
     method: "POST",
     headers,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       "devDependencies": {
         "ava": "3.15.0",
         "esbuild": "^0.12.28",
-        "fetch-mock": "9.11.0",
+        "esmock": "^0.4.0",
+        "fetch-mock": "^9.11.0",
         "pre-commit": "1.2.2",
         "quibble": "0.6.5"
       }
@@ -937,68 +938,18 @@
       }
     },
     "node_modules/ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "dev": true,
       "dependencies": {
-        "string-width": "^3.0.0"
-      }
-    },
-    "node_modules/ansi-align/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-align/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
-    },
-    "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ansi-align/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-align/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "string-width": "^4.1.0"
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -2057,6 +2008,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esmock": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-0.4.0.tgz",
+      "integrity": "sha512-Hp9q57+JOV2iejaDDxZQgaTCaKog1aiyiIMSQpboxmLYcGPkCbhSS3z4m3IQhpoDRYv7O2fKiXxNHKXWgw8r2A==",
+      "dev": true,
+      "dependencies": {
+        "resolvewithplus": "^0.2.0"
       }
     },
     "node_modules/esprima": {
@@ -3229,9 +3189,9 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3509,9 +3469,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -3951,6 +3911,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/resolvewithplus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/resolvewithplus/-/resolvewithplus-0.2.0.tgz",
+      "integrity": "sha512-TST6Ttys5b2PFeq3rVaazuQuoErtUYmKnf2wbCImmaRqBakPrFeIcz2vevomf+H14VB5hipCZItUAY1DZSP6ig==",
+      "dev": true
     },
     "node_modules/responselike": {
       "version": "1.0.2",
@@ -4489,9 +4455,9 @@
       }
     },
     "node_modules/trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.2.tgz",
+      "integrity": "sha512-DAnbtY4lNoOTLw05HLuvPoBFAGV4zOKQ9d1Q45JB+bcDwYIEkCr0xNgwKtygtKFBbRlFA/8ytkAM1V09QGWksg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5471,58 +5437,18 @@
       }
     },
     "ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "dev": true,
       "requires": {
-        "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
+        "string-width": "^4.1.0"
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -6342,6 +6268,15 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "esmock": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-0.4.0.tgz",
+      "integrity": "sha512-Hp9q57+JOV2iejaDDxZQgaTCaKog1aiyiIMSQpboxmLYcGPkCbhSS3z4m3IQhpoDRYv7O2fKiXxNHKXWgw8r2A==",
+      "dev": true,
+      "requires": {
+        "resolvewithplus": "^0.2.0"
+      }
     },
     "esprima": {
       "version": "4.0.1",
@@ -7233,9 +7168,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "number-to-bn": {
@@ -7434,9 +7369,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {
@@ -7759,6 +7694,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true
+    },
+    "resolvewithplus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/resolvewithplus/-/resolvewithplus-0.2.0.tgz",
+      "integrity": "sha512-TST6Ttys5b2PFeq3rVaazuQuoErtUYmKnf2wbCImmaRqBakPrFeIcz2vevomf+H14VB5hipCZItUAY1DZSP6ig==",
       "dev": true
     },
     "responselike": {
@@ -8155,9 +8096,9 @@
       }
     },
     "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.2.tgz",
+      "integrity": "sha512-DAnbtY4lNoOTLw05HLuvPoBFAGV4zOKQ9d1Q45JB+bcDwYIEkCr0xNgwKtygtKFBbRlFA/8ytkAM1V09QGWksg==",
       "dev": true
     },
     "type-fest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
         "esbuild": "^0.12.28",
         "esmock": "^0.4.0",
         "fetch-mock": "^9.11.0",
-        "pre-commit": "1.2.2",
-        "quibble": "0.6.5"
+        "pre-commit": "1.2.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3719,20 +3718,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/quibble": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.5.tgz",
-      "integrity": "sha512-L3/bDHWjHm9zdG0Aqj7lhmp6Q5RFjXeitO9CGzWKP83d6BlGS0lLo9oswxgq62gwuIF7apT9tO0dw9kNuvb9eg==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.14",
-        "resolve": "^1.11.1"
-      },
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -7545,16 +7530,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "quibble": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.5.tgz",
-      "integrity": "sha512-L3/bDHWjHm9zdG0Aqj7lhmp6Q5RFjXeitO9CGzWKP83d6BlGS0lLo9oswxgq62gwuIF7apT9tO0dw9kNuvb9eg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14",
-        "resolve": "^1.11.1"
-      }
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "esbuild": "^0.12.28",
     "esmock": "^0.4.0",
     "fetch-mock": "^9.11.0",
-    "pre-commit": "1.2.2",
-    "quibble": "0.6.5"
+    "pre-commit": "1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "ava": {
     "nodeArguments": [
-      "--loader=quibble",
+      "--loader=esmock",
       "--no-warnings"
     ]
   },
@@ -44,7 +44,8 @@
   "devDependencies": {
     "ava": "3.15.0",
     "esbuild": "^0.12.28",
-    "fetch-mock": "9.11.0",
+    "esmock": "^0.4.0",
+    "fetch-mock": "^9.11.0",
     "pre-commit": "1.2.2",
     "quibble": "0.6.5"
   }

--- a/test/blockNumber_test.js
+++ b/test/blockNumber_test.js
@@ -1,12 +1,34 @@
 // @format
 import test from "ava";
+import esmock from "esmock";
+import fetchMock from "fetch-mock";
 
-import getBlockNumber from "../src/blockNumber.js";
-
-test("getting block number", async t => {
+test("getting block number", async (t) => {
   const options = {
     url: "https://cloudflare-eth.com",
   };
+
+  const { default: getBlockNumber } = await esmock(
+    "../src/blockNumber.js",
+    null,
+    {
+      "cross-fetch": {
+        default: fetchMock.sandbox().post(
+          {
+            url: options.url,
+            body: {
+              method: "eth_blockNumber",
+            },
+            matchPartialBody: true,
+          },
+          {
+            result: "0xcd2057",
+          }
+        ),
+      },
+    }
+  );
+
   const no = await getBlockNumber(options);
   t.is(typeof no, "string");
   t.true(no.includes("0x"));

--- a/test/blockNumber_test.js
+++ b/test/blockNumber_test.js
@@ -3,6 +3,8 @@ import test from "ava";
 import esmock from "esmock";
 import fetchMock from "fetch-mock";
 
+import constants from "../src/constants.js";
+
 test("getting block number", async (t) => {
   const options = {
     url: "https://cloudflare-eth.com",
@@ -18,8 +20,9 @@ test("getting block number", async (t) => {
             url: options.url,
             body: {
               method: "eth_blockNumber",
+              params: [],
+              ...constants,
             },
-            matchPartialBody: true,
           },
           {
             result: "0xcd2057",

--- a/test/call_test.js
+++ b/test/call_test.js
@@ -4,6 +4,7 @@ import esmock from "esmock";
 import fetchMock from "fetch-mock";
 
 import { encodeCallSignature, decodeCallOutput } from "../src/call.js";
+import constants from "../src/constants.js";
 
 test("if encoding a eth call works", (t) => {
   const selector = "baz(uint32,bool)";
@@ -46,8 +47,8 @@ test("if getBalance eth_call works on DSS contract", async (t) => {
           body: {
             method: "eth_call",
             params: [{ from, to, data }, blockNumber],
+            ...constants,
           },
-          matchPartialBody: true,
         },
         {
           result:
@@ -88,8 +89,8 @@ test("if null can be passed to from and call still works", async (t) => {
           body: {
             method: "eth_call",
             params: [{ to, data }, blockNumber],
+            ...constants,
           },
-          matchPartialBody: true,
         },
         {
           result:

--- a/test/call_test.js
+++ b/test/call_test.js
@@ -1,28 +1,32 @@
 // @format
 import test from "ava";
+import esmock from "esmock";
+import fetchMock from "fetch-mock";
 
-import { call, encodeCallSignature, decodeCallOutput } from "../src/call.js";
+import { encodeCallSignature, decodeCallOutput } from "../src/call.js";
 
-test("if encoding a eth call works", t => {
+test("if encoding a eth call works", (t) => {
   const selector = "baz(uint32,bool)";
   const types = ["uint32", "bool"];
   const values = [69, true];
 
   // REFERENCE: https://docs.soliditylang.org/en/develop/abi-spec.html#examples
-  const expected = "0xcdcd77c000000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000001";
+  const expected =
+    "0xcdcd77c000000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000001";
   t.is(encodeCallSignature(selector, types, values), expected);
 });
 
-test("if decoding a eth call result works", t => {
+test("if decoding a eth call result works", (t) => {
   const types = ["uint256"];
-  const output = "0x00000000000000000000000000000000000000000000000041eb63d55b1b0000";
+  const output =
+    "0x00000000000000000000000000000000000000000000000041eb63d55b1b0000";
   const expected = "4750000000000000000";
-  t.is(expected/Math.pow(10, 18), 4.75);
+  t.is(expected / Math.pow(10, 18), 4.75);
   const [res] = decodeCallOutput(types, output);
   t.is(res, expected);
 });
 
-test("if getBalance eth_call works on DSS contract", async t => {
+test("if getBalance eth_call works on DSS contract", async (t) => {
   const from = "0x005241438cAF3eaCb05bB6543151f7AF894C5B58";
   const to = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
   const selector = "balanceOf(address)";
@@ -31,8 +35,27 @@ test("if getBalance eth_call works on DSS contract", async t => {
   const blockNumber = "latest";
   const data = encodeCallSignature(selector, inputTypes, values);
   const options = {
-    url: "https://cloudflare-eth.com"
+    url: "https://cloudflare-eth.com",
   };
+
+  const { call } = await esmock("../src/call.js", null, {
+    "cross-fetch": {
+      default: fetchMock.sandbox().post(
+        {
+          url: options.url,
+          body: {
+            method: "eth_call",
+            params: [{ from, to, data }, blockNumber],
+          },
+          matchPartialBody: true,
+        },
+        {
+          result:
+            "0x00000000000000000000000000000000000000000000000041eb63d55b1b0000",
+        }
+      ),
+    },
+  });
 
   const output = await call(options, from, to, data, blockNumber);
   t.truthy(output);
@@ -45,7 +68,7 @@ test("if getBalance eth_call works on DSS contract", async t => {
   t.is(res, expected);
 });
 
-test("if null can be passed to from and call still works", async t => {
+test("if null can be passed to from and call still works", async (t) => {
   const from = null;
   const to = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
   const selector = "balanceOf(address)";
@@ -54,8 +77,27 @@ test("if null can be passed to from and call still works", async t => {
   const blockNumber = "latest";
   const data = encodeCallSignature(selector, inputTypes, values);
   const options = {
-    url: "https://cloudflare-eth.com"
+    url: "https://cloudflare-eth.com",
   };
+
+  const { call } = await esmock("../src/call.js", null, {
+    "cross-fetch": {
+      default: fetchMock.sandbox().post(
+        {
+          url: options.url,
+          body: {
+            method: "eth_call",
+            params: [{ to, data }, blockNumber],
+          },
+          matchPartialBody: true,
+        },
+        {
+          result:
+            "0x00000000000000000000000000000000000000000000000041eb63d55b1b0000",
+        }
+      ),
+    },
+  });
 
   const output = await call(options, from, to, data, blockNumber);
   t.truthy(output);

--- a/test/getBlockByNumber_test.js
+++ b/test/getBlockByNumber_test.js
@@ -1,13 +1,35 @@
 // @format
 import test from "ava";
+import esmock from "esmock";
+import fetchMock from "fetch-mock";
 
-import { blockNumber, getBlockByNumber } from "../src/index.js";
-
-test("getting a block full of transactions", async t => {
+test("getting a block full of transactions", async (t) => {
   const options = {
-    url: "https://cloudflare-eth.com"
+    url: "https://cloudflare-eth.com",
   };
-  const currentNumber = await blockNumber(options);
+
+  const { getBlockByNumber } = await esmock("../src/index.js", null, {
+    "cross-fetch": {
+      default: fetchMock.sandbox().post(
+        {
+          url: options.url,
+          body: {
+            method: "eth_getBlockByNumber",
+          },
+          matchPartialBody: true,
+        },
+        {
+          result: {
+            transactions: [
+              "0x2495242be275427e68efe7be41d1487dba505642f349d99bca63bc17787661c8",
+            ],
+          },
+        }
+      ),
+    },
+  });
+
+  const currentNumber = "0xcd2057";
   const includeTxBody = false;
   const block = await getBlockByNumber(options, currentNumber, includeTxBody);
   t.truthy(block);

--- a/test/getBlockByNumber_test.js
+++ b/test/getBlockByNumber_test.js
@@ -3,10 +3,14 @@ import test from "ava";
 import esmock from "esmock";
 import fetchMock from "fetch-mock";
 
+import constants from "../src/constants.js";
+
 test("getting a block full of transactions", async (t) => {
   const options = {
     url: "https://cloudflare-eth.com",
   };
+  const currentNumber = "0xcd2057";
+  const includeTxBody = false;
 
   const { getBlockByNumber } = await esmock("../src/index.js", null, {
     "cross-fetch": {
@@ -15,8 +19,9 @@ test("getting a block full of transactions", async (t) => {
           url: options.url,
           body: {
             method: "eth_getBlockByNumber",
+            params: [currentNumber, includeTxBody],
+            ...constants,
           },
-          matchPartialBody: true,
         },
         {
           result: {
@@ -29,8 +34,6 @@ test("getting a block full of transactions", async (t) => {
     },
   });
 
-  const currentNumber = "0xcd2057";
-  const includeTxBody = false;
   const block = await getBlockByNumber(options, currentNumber, includeTxBody);
   t.truthy(block);
   t.truthy(block.transactions);

--- a/test/getStorageAt_test.js
+++ b/test/getStorageAt_test.js
@@ -1,12 +1,14 @@
 // @format
 import test from "ava";
+import esmock from "esmock";
+import fetchMock from "fetch-mock";
 
 import { toHex } from "../src/utils.js";
-import { bodyFactory, getStorageAt } from "../src/getStorageAt.js";
+import { bodyFactory } from "../src/getStorageAt.js";
 
 const addr = "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984";
 
-test("body factory", t => {
+test("body factory", (t) => {
   const index = 1;
   const blockNo = "latest";
   const contract = "abc";
@@ -15,13 +17,26 @@ test("body factory", t => {
   t.truthy(res.params[2]);
 });
 
-test("if getting index works", async t => {
+test("if getting index works", async (t) => {
   const index = 1;
   const blockNo = "latest";
 
   const options = {
-    url: "https://cloudflare-eth.com"
+    url: "https://cloudflare-eth.com",
   };
+
+  const { getStorageAt } = await esmock("../src/getStorageAt.js", null, {
+    "cross-fetch": {
+      default: fetchMock.sandbox().post(
+        {},
+        {
+          result:
+            "0x0000000000000000000000001a9c8182c09f50c8318d769245bea52c32be35bc",
+        }
+      ),
+    },
+  });
+
   const storage = await getStorageAt(options, addr, index, blockNo);
   t.is(storage.length, 64 + 2);
 });


### PR DESCRIPTION
Closes #14 

- I have used esmock along with fetch-mock. I could have skipped fetch-mock and mocked the `transport.js` module but then the tests would have lost their purpose.
- I have tried mocking network calls *strictly*. Instead of sending a response for any call I check for the method, URL and body.
- There are still network calls for the readme tests.

A brief explanation of the syntax.

```js
const { default: getBlockNumber } = await esmock(
  "../src/blockNumber.js", // Module to be mocked
  null,
  {
   // Mock cross-fetch where ever it is imported
    "cross-fetch": {
      // This fetch-mock instance is the default export of cross-fetch
      default: fetchMock.sandbox().post(
        // Matcher object
        {
          url: options.url,
          body: {
            method: "eth_blockNumber",
          },
          matchPartialBody: true,
        },
        // Response object
        {
          result: "0xcd2057",
        }
      ),
    },
  }
);
```