### PR TITLE
Prevent eth_call from returning `undefined`

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -112,6 +112,9 @@ async function send(options, body) {
   } catch (err) {
     throw new RPCError(`Encountered error when trying to parse JSON body result: "${result}", error: "${err.toString()}"`);
   }
+  if (data.error && data.error.message) {
+    throw new RPCError(`Error from fullnode: ${data.error.message}`);
+  }
   return data.result;
 }
 

--- a/src/transport.js
+++ b/src/transport.js
@@ -47,5 +47,11 @@ export async function send(options, body) {
     );
   }
 
+  // NOTE: Finally, this matches when the full node throws a JSON
+  // RPC error.
+  if (data.error && data.error.message) {
+    throw new RPCError(`Error from fullnode: ${data.error.message}`);
+  }
+
   return data.result;
 }

--- a/test/call_test.js
+++ b/test/call_test.js
@@ -4,6 +4,7 @@ import esmock from "esmock";
 import fetchMock from "fetch-mock";
 
 import { encodeCallSignature, decodeCallOutput } from "../src/call.js";
+import { RPCError } from "../src/errors.js";
 import constants from "../src/constants.js";
 
 test("eth_call with non-hex block number tag must not return undefined", async (t) => {
@@ -19,9 +20,9 @@ test("eth_call with non-hex block number tag must not return undefined", async (
   };
 
   const { call } = await import("../src/call.js");
-
-  const output = await call(options, from, to, data, blockNumber);
-  t.not(output, undefined);
+  await t.throwsAsync(
+    async () => await call(options, from, to, data, blockNumber)
+  );
 });
 
 test("if encoding a eth call works", (t) => {

--- a/test/call_test.js
+++ b/test/call_test.js
@@ -6,6 +6,24 @@ import fetchMock from "fetch-mock";
 import { encodeCallSignature, decodeCallOutput } from "../src/call.js";
 import constants from "../src/constants.js";
 
+test("eth_call with non-hex block number tag must not return undefined", async (t) => {
+  const from = "0x005241438cAF3eaCb05bB6543151f7AF894C5B58";
+  const to = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+  const selector = "balanceOf(address)";
+  const inputTypes = ["address"];
+  const values = [from];
+  const blockNumber = "1234";
+  const data = encodeCallSignature(selector, inputTypes, values);
+  const options = {
+    url: "https://cloudflare-eth.com",
+  };
+
+  const { call } = await import("../src/call.js");
+
+  const output = await call(options, from, to, data, blockNumber);
+  t.not(output, undefined);
+});
+
 test("if encoding a eth call works", (t) => {
   const selector = "baz(uint32,bool)";
   const types = ["uint32", "bool"];


### PR DESCRIPTION
"eth_call" should throw an error when a false block tag is returned. Or more generally: eth_call should never return `undefined`.